### PR TITLE
fix: deprecate strings.TrimSpace

### DIFF
--- a/pkg/strings/strings.go
+++ b/pkg/strings/strings.go
@@ -290,6 +290,7 @@ func Replace(name string) *jsonnet.NativeFunction {
 	}
 }
 
+// Deprecated: Use std.trim(str) instead.
 func TrimSpace(name string) *jsonnet.NativeFunction {
 	return &jsonnet.NativeFunction{
 		Name:   name,


### PR DESCRIPTION
Deprecated: Use std.trim(str) instead.

https://jsonnet.org/ref/stdlib.html